### PR TITLE
수정사항-2

### DIFF
--- a/WebContent/WEB-INF/views/forum/notice/list.jsp
+++ b/WebContent/WEB-INF/views/forum/notice/list.jsp
@@ -28,7 +28,7 @@ String ctx = request.getContextPath();
 									<tbody>
 										<c:forEach items="${list}" var="i" varStatus="status">
 											<tr>
-												<td>${i.boardSeq}</td>
+												<td>${totalCnt-(currentPage-1)*10-status.index}</td>
 												<td><a
 													href="<c:url value='/forum/notice/readPage.do?boardSeq=${i.boardSeq}&boardTypeSeq=${i.boardTypeSeq}'/>">
 														${i.title} </a> <%-- &nbsp;<c:if test="${commentCounts[i.boardSeq] != 0}"><a>(${commentCounts[i.boardSeq]})</a></c:if> --%>

--- a/WebContent/WEB-INF/views/forum/notice/read.jsp
+++ b/WebContent/WEB-INF/views/forum/notice/read.jsp
@@ -23,6 +23,11 @@ String ctx = request.getContextPath();
 		transition: max-height 0.2s ease-out;
 	}
 	
+	.panel.active {
+	    max-height: 300px; /* 수정 폼의 최대 높이 설정 */
+	    opacity: 1;
+	}
+	
 	.commentButton {
 		width:45px;
 		height:25px;
@@ -110,21 +115,22 @@ String ctx = request.getContextPath();
 									        <p>${comment.content}</p>
 									    </div>
 										
-									    <c:if test="${logInUser eq comment.memberNm}">
-									    	<input class="commentButton" id="cmtEditToggle" type="submit" value="수정"/>
-									    	&nbsp;
-									        <div style="margin-right: 10px;">
-									            <form action="deleteComment.do" method="post">
-									                <input type="hidden" name="logInUser" value="${logInUser}"/>
-									                <input type="hidden" name="boardTypeSeq" value="${boardTypeSeq}"/>
-									                <input type="hidden" name="boardSeq" value="${boardSeq}"/>
-									                <input type="hidden" name="commentSeq" value="${comment.commentSeq}"/>
-									                <a href="javascript:void(0)">
-									                    <input class="commentButton" type="submit" value="삭제"/>
-									                </a>
-									            </form>
-									        </div>
-									    </c:if>
+										<!-- 수정 버튼 -->
+										<c:if test="${logInUser eq comment.memberNm}">
+										    <input class="commentButton cmtEditToggle" type="button" value="수정" onclick="editToggle(${comment.commentSeq})"/>
+										    &nbsp;
+										    <div style="margin-right: 10px;">
+										        <form action="deleteComment.do" method="post">
+										            <input type="hidden" name="logInUser" value="${logInUser}"/>
+										            <input type="hidden" name="boardTypeSeq" value="${boardTypeSeq}"/>
+										            <input type="hidden" name="boardSeq" value="${boardSeq}"/>
+										            <input type="hidden" name="commentSeq" value="${comment.commentSeq}"/>
+										            <a href="javascript:void(0)">
+										                <input class="commentButton" type="submit" value="삭제"/>
+										            </a>
+										        </form>
+										    </div>
+										</c:if>
 									
 										<div class="vote" style="flex: 0 0 auto; text-align: right;">
 										    <a href="#" onClick="javascript:commentIsLike(${boardSeq}, ${boardTypeSeq}, 'Y', ${comment.commentSeq});"
@@ -150,18 +156,18 @@ String ctx = request.getContextPath();
 							</div>
 							<!-- 댓글 수정내용 입력칸 -->
 							<c:if test="${logInUser eq comment.memberNm}">
-								<form class="panel" action="updateComment.do" method="post" style="display:flex; border:1px solid rgba(0, 0, 0, 0.2)">
-									<input type="hidden" name="logInUser" value="${logInUser}"/>
-									<input type="hidden" name="boardTypeSeq" value="${boardTypeSeq}"/>
-									<input type="hidden" name="boardSeq" value="${boardSeq}"/>
-									<input type="hidden" name="commentSeq" value="${comment.commentSeq}"/>
-									<div style="width:90%">
-										<input type="text" name="content" placeholder="수정할 댓글 내용을 입력해주세요."/>
-									</div>
-									<div style="width:10%">
-										<input type="submit" value="수정" style="width:100%"/>
-									</div>
-								</form>
+							    <form class="panel panel-${comment.commentSeq}" action="updateComment.do" method="post" style="display:flex; border:1px solid rgba(0, 0, 0, 0.2)">
+							        <input type="hidden" name="logInUser" value="${logInUser}"/>
+							        <input type="hidden" name="boardTypeSeq" value="${boardTypeSeq}"/>
+							        <input type="hidden" name="boardSeq" value="${boardSeq}"/>
+							        <input type="hidden" name="commentSeq" value="${comment.commentSeq}"/>
+							        <div style="width:90%">
+							            <input type="text" name="content" placeholder="수정할 댓글 내용을 입력해주세요."/>
+							        </div>
+							        <div style="width:10%">
+							            <input type="submit" value="수정" style="width:100%"/>
+							        </div>
+							    </form>
 							</c:if>
 							<!-- 댓글 수정내용 입력칸 끝 -->
 							<!-- end .forum_single_reply -->
@@ -309,18 +315,21 @@ String ctx = request.getContextPath();
 			}
 		}
 		
-		window.onload = function () {
-			document.getElementById('cmtEditToggle').addEventListener('click', function() {
-			    var panel = document.querySelector('.panel');
-			    if (panel.style.maxHeight) {
-			        panel.style.maxHeight = null;
-			        panel.style.opacity = 0;
-			    } else {
-			        panel.style.maxHeight = panel.scrollHeight + 'px';
-			        panel.style.opacity = 1;
-			    }
-			});
+		// 댓글수정 토글방식 변경
+		function editToggle(commentSeq) {
+		    var panel = document.querySelector('.panel-' + commentSeq);
+		    panel.classList.toggle('active');
 		}
+
+		window.onload = function() {
+		    var elements = document.querySelectorAll('.cmtEditToggle');
+		    elements.forEach(function(element) {
+		        element.addEventListener('click', function() {
+		            editToggle(element.getAttribute('data-commentSeq'));
+		        });
+		    });
+		};
+		
     </script>
 <!--================================
             END DASHBOARD AREA

--- a/src/main/java/com/portfolio/www/forum/notice/NoticeController.java
+++ b/src/main/java/com/portfolio/www/forum/notice/NoticeController.java
@@ -312,6 +312,7 @@ public class NoticeController {
 		mv.addObject("currentPage", page);
 		mv.addObject("hasPrev", pageHandler.isShowPrev());
 		mv.addObject("hasNext", pageHandler.isShowNext());
+		mv.addObject("totalCnt", totalCnt);
 		// 페이징 끝
 
 		// 게시글리스트 출력

--- a/src/main/resource-common/sql/SQL.Notice.xml
+++ b/src/main/resource-common/sql/SQL.Notice.xml
@@ -197,32 +197,32 @@
 	<!-- 게시글 리스트 가져오기 -->
 	<select id="getList" parameterType="map" resultType="BoardDto">
 		SELECT
-		b.board_seq,
-		b.board_type_seq,
-		b.title,
-		b.content,
-		b.hit,
-		b.del_yn,
-		b.reg_dtm,
-		b.reg_member_seq,
-		m.member_id,
-		b.update_dtm,
-		b.update_member_seq,
-		bt.board_type_nm
+			b.board_seq,
+			b.board_type_seq,
+			b.title,
+			b.content,
+			b.hit,
+			b.del_yn,
+			b.reg_dtm,
+			b.reg_member_seq,
+			m.member_id,
+			b.update_dtm,
+			b.update_member_seq,
+			bt.board_type_nm
 		FROM
-		board b
+			board b
 		JOIN
-		board_type bt ON
-		bt.board_type_seq = b.board_type_seq
+			board_type bt ON
+			bt.board_type_seq = b.board_type_seq
 		JOIN
-		member m ON m.member_seq =
-		b.reg_member_seq
+			member m ON m.member_seq =
+			b.reg_member_seq
 		WHERE
-		b.board_type_seq = #{bdTypeSeq}
+			b.board_type_seq = #{bdTypeSeq}
 		ORDER BY
-		b.board_seq DESC
+			b.board_seq DESC
 		LIMIT
-		#{start}, #{size};
+			#{start}, #{size};
 	</select>
 
 	<!-- 게시글 총 개수 가져오기 -->


### PR DESCRIPTION
한 것

댓글수정 토글방식 변경 완료
 > 기존 : 내가 적은 댓글이 여러개일 경우 맨 위에 하나만 수정이 가능했다.
 > 현재 : 전부 수정 가능함


게시글 넘버표시 board_seq 그대로 쓰지 말기
 1-1. board_seq를 그대로 쓰니까 게시글 넘버가 1,2,3,4,5,6,7 이런 식으로 표시되는것이 아니라
게시글을 삭제했을 때 1, 3, 6, 11, 16 이런식으로 삭제한 게시글의 번호가 빔
 1-2. 어떻게 넘버링을 해야 할까
>>> 기존 : ${i.boardSeq}
>>> 변경 : ${totalCnt-(currentPage-1)*10-status.index}
>>> 총 게시물 개수 - (현재 페이지 - 1)
 * 10(한  페이지에 보여주는 게시글 수) - 현재 페이지에 가져온 게시글 순번 (0~9까지)