### PR TITLE
게시판 클릭 시 NullPointerException 발생 해결

### DIFF
--- a/src/main/java/com/portfolio/www/forum/notice/NoticeController.java
+++ b/src/main/java/com/portfolio/www/forum/notice/NoticeController.java
@@ -306,7 +306,7 @@ public class NoticeController {
 
 	    // 아이디 인증여부 확인
 	    String authYN = noticeService.getAuthYN(loginMember);
-		if(authYN.equals("N")) {
+		if("N".equals(authYN)) {
 			params.put("logInUser", loginMember);
 			noticeService.updateAuthNum(params);
 			String getEmail = noticeService.getEmail(loginMember);


### PR DESCRIPTION
authYN.equals("N") > "N".equals(authYN) 으로 변경
> 이렇게 바꿔야 'authYN'이 NULL일 경우에도 안전하게 eqauls 호출 가능