### PR TITLE
413 Request Entity Too Large 해결

### DIFF
--- a/src/main/java/com/portfolio/www/forum/notice/NoticeController.java
+++ b/src/main/java/com/portfolio/www/forum/notice/NoticeController.java
@@ -266,15 +266,15 @@ public class NoticeController {
 
 		String createResult = noticeService.boardCreate(params, request, attFiles);
 		
-	    if (createResult.equals("4001")) {
-	        redirectAttributes.addAttribute("errorMsg", MessageEnum.FAILD_BOARD.getDescription());
-	    } else if(createResult.equals("4002")) {
-	        redirectAttributes.addAttribute("errorMsg", MessageEnum.FAILD_BOARD_LOGIN.getDescription());
-	    } else if(createResult.equals("4100")){
-	        redirectAttributes.addFlashAttribute("errorMsg", MessageEnum.FAILD_BOARD_SIZE.getDescription());
-	        return "redirect:/forum/notice/writePage.do?boardTypeSeq=" + boardTypeSeq;
-	    }
-	    return "redirect:/forum/notice/listPage.do?bdTypeSeq=" + boardTypeSeq;
+		if(createResult.equals(MessageEnum.FAILD_BOARD.getCode())) {
+		    redirectAttributes.addAttribute("errorMsg", MessageEnum.FAILD_BOARD.getDescription());
+		} else if(createResult.equals(MessageEnum.FAILD_BOARD_LOGIN.getCode())) {
+		    redirectAttributes.addAttribute("errorMsg", MessageEnum.FAILD_BOARD_LOGIN.getDescription());
+		} else if(createResult.equals(MessageEnum.FAILD_BOARD_SIZE.getCode())) {
+		    redirectAttributes.addFlashAttribute("errorMsg", MessageEnum.FAILD_BOARD_SIZE.getDescription());
+		    return "redirect:/forum/notice/writePage.do?boardTypeSeq=" + boardTypeSeq;
+		}
+		return "redirect:/forum/notice/listPage.do?bdTypeSeq=" + boardTypeSeq;
 	}
 
 	// 게시글 삭제 > 댓글이 있을 경우 댓글도 다 같이 삭제해줘야 함 noticeService에서 처리할 것

--- a/src/main/java/com/portfolio/www/service/NoticeService.java
+++ b/src/main/java/com/portfolio/www/service/NoticeService.java
@@ -400,7 +400,6 @@ public class NoticeService {
 		noticeRepository.deleteAllComment(boardTypeSeq, boardSeq); // 댓글 삭제
 		return noticeRepository.boardDelete(memberId, boardTypeSeq, boardSeq); // 게시글 삭제
 	}
-
 	
 	// ---------------------------------------------------------------------------------------
 	// 게시판 내 게시글 불러오기

--- a/src/main/java/com/portfolio/www/util/FileUtil.java
+++ b/src/main/java/com/portfolio/www/util/FileUtil.java
@@ -14,6 +14,9 @@ import org.springframework.web.multipart.MultipartFile;
 @Component
 public class FileUtil {
 	
+	// 업로드 용량 제한
+	private static final long MAX_FILE_SIZE_BYTES = 1024 * 1024; // 1MB
+	
 	// 날짜출력형식 지정
 	SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
 	// 지정한 형식을 바탕으로 날짜 출력
@@ -32,11 +35,10 @@ public class FileUtil {
 			// 업로드하는 파일 크기
 			long getByte = mf.getSize();
 			
-			if(getByte>1048575) {
+			if(getByte > MAX_FILE_SIZE_BYTES) {
 				System.out.println("파일의 크기는 1MB를 넘을 수 없습니다.");
-		        throw new MaxUploadSizeExceededException(1048576);
+		        throw new MaxUploadSizeExceededException(MAX_FILE_SIZE_BYTES);
 			}
-			
 			
 			// 업로드된 파일이 없거나 비어 있는 경우 예외를 던져서 빈 파일이 저장되지 않도록 방지
 		    if(mf == null || mf.isEmpty()) {


### PR DESCRIPTION
## 1. 애플리케이션 레벨에서 파일 크기 제한 구현
- MaxUploadSizeExceededException 예외 사용
- ENUM을 활용한 에러 코드 및 메시지 관리

## 2. 사용자 경험 개선
- 1MB 초과 파일 업로드 파일 업로드 차단
- 사용자에게 알람 표시

## 참고사항
- Nginx 설정 변경
- nginx.conf에서 업로드 크기 제한을 2MB로 늘려서 배포환경에서 여전히 발생하던 문제를 해결.